### PR TITLE
Enable Bump GitHub action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,36 @@
+name: Check &amp; deploy API documentation
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+jobs:
+  deploy-doc:
+    if: ${{ github.event_name == 'push' }}
+    name: Deploy API documentation on Bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bump-sh/github-action@v1
+        with:
+          doc: restaurants-api
+          token: ${{ secrets.BUMP_DOC_TOKEN }}
+          file: lib/docs/restaurantsAPI.yml
+  api-diff:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Check API diff on Bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bump-sh/github-action@v1
+        with:
+          doc: restaurants-api
+          token: ${{ secrets.BUMP_DOC_TOKEN }}
+          file: lib/docs/restaurantsAPI.yml
+          command: diff
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Let's enable GitHub action from Bump, with two steps:

a validation & diff step on code reviews,
followed by a deployment step on merged changes.

---

Source:

https://help.bump.sh/continuous-integration/github-actions

https://github.com/bump-sh/github-action

